### PR TITLE
fix: remove config volume & expose claim templates

### DIFF
--- a/stateful/Chart.yaml
+++ b/stateful/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: stateful
 description: A generic chart for stateful Web applications (e.g. Radarr)
-version: 1.0.0
+version: 1.1.0
 type: application

--- a/stateful/templates/statefulset.yaml
+++ b/stateful/templates/statefulset.yaml
@@ -44,8 +44,6 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: arr-config
-              mountPath: /config
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -58,11 +56,6 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
   volumeClaimTemplates:
-    - metadata:
-        name: arr-config
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.persistence.config.storageClass }}
-        resources:
-          requests:
-            storage: {{ .Values.persistence.config.size }}
+    {{- with .Values.extraVolumeClaimTemplates }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/stateful/values.yaml
+++ b/stateful/values.yaml
@@ -5,10 +5,6 @@ image:
   pullPolicy: Always
   tag: ""
 
-persistence:
-  config:
-    size: 512Mi
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -67,6 +63,17 @@ extraVolumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
+
+# Additional volumeClaimTemplates on the output StatefulSet definition.
+extraVolumeClaimTemplates: []
+# - metadata:
+#     name: foo
+#   spec:
+#     accessModes: [ "ReadWriteOnce" ]
+#     storageClassName: "foo"
+#     resources:
+#       requests:
+#         storage: 1Gi
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Remove the config volume and expose claim templates through a chart value, as should be done in a generic chart.
